### PR TITLE
feat!: use environments for content type operations

### DIFF
--- a/content_type.go
+++ b/content_type.go
@@ -290,8 +290,8 @@ func (ct *ContentType) GetVersion() int {
 }
 
 // List return a content type collection
-func (service *ContentTypesService) List(spaceID string) *Collection {
-	path := fmt.Sprintf("/spaces/%s/content_types", spaceID)
+func (service *ContentTypesService) List(env *Environment) *Collection {
+	path := fmt.Sprintf("/spaces/%s/environments/%s/content_types", env.Sys.Space.Sys.ID, env.Sys.ID)
 	method := "GET"
 
 	req, err := service.c.newRequest(method, path, nil, nil)
@@ -307,8 +307,8 @@ func (service *ContentTypesService) List(spaceID string) *Collection {
 }
 
 // ListActivated return a content type collection, with only activated content types
-func (service *ContentTypesService) ListActivated(spaceID string) *Collection {
-	path := fmt.Sprintf("/spaces/%s/public/content_types", spaceID)
+func (service *ContentTypesService) ListActivated(env *Environment) *Collection {
+	path := fmt.Sprintf("/spaces/%s/environments/%s/public/content_types", env.Sys.Space.Sys.ID, env.Sys.ID)
 	method := "GET"
 
 	req, err := service.c.newRequest(method, path, nil, nil)
@@ -323,21 +323,10 @@ func (service *ContentTypesService) ListActivated(spaceID string) *Collection {
 	return col
 }
 
-// Get fetched a content type specified by `contentTypeID`
-func (service *ContentTypesService) Get(spaceID, contentTypeID string) (*ContentType, error) {
-	path := fmt.Sprintf("/spaces/%s/content_types/%s", spaceID, contentTypeID)
-
-	return service.doGet(path)
-}
-
-// GetFromEnv a content type by `contentTypeID` from an environment
-func (service *ContentTypesService) GetFromEnv(env *Environment, contentTypeID string) (*ContentType, error) {
+// Get a content type by `contentTypeID` from an environment
+func (service *ContentTypesService) Get(env *Environment, contentTypeID string) (*ContentType, error) {
 	path := fmt.Sprintf("/spaces/%s/environments/%s/content_types/%s", env.Sys.Space.Sys.ID, env.Sys.ID, contentTypeID)
 
-	return service.doGet(path)
-}
-
-func (service *ContentTypesService) doGet(path string) (*ContentType, error) {
 	req, err := service.c.newRequest("GET", path, nil, nil)
 	if err != nil {
 		return nil, err
@@ -351,21 +340,8 @@ func (service *ContentTypesService) doGet(path string) (*ContentType, error) {
 	return &ct, nil
 }
 
-// Upsert updates or creates a new content type
-func (service *ContentTypesService) Upsert(spaceID string, ct *ContentType) error {
-	var path string
-
-	if ct.Sys != nil && ct.Sys.ID != "" {
-		path = fmt.Sprintf("/spaces/%s/content_types/%s", spaceID, ct.Sys.ID)
-	} else {
-		path = fmt.Sprintf("/spaces/%s/content_types/%s", spaceID, ct.Name)
-	}
-
-	return service.doUpsert(path, ct)
-}
-
-// UpsertEnv a content type for an environment
-func (service *ContentTypesService) UpsertEnv(env *Environment, ct *ContentType) error {
+// Upsert a content type for an environment
+func (service *ContentTypesService) Upsert(env *Environment, ct *ContentType) error {
 	var path string
 
 	path = fmt.Sprintf("/spaces/%s/environments/%s", env.Sys.Space.Sys.ID, env.Sys.ID)
@@ -376,10 +352,6 @@ func (service *ContentTypesService) UpsertEnv(env *Environment, ct *ContentType)
 		path = fmt.Sprintf("%s/content_types/%s", path, ct.Name)
 	}
 
-	return service.doUpsert(path, ct)
-}
-
-func (service *ContentTypesService) doUpsert(path string, ct *ContentType) error {
 	bytesArray, err := json.Marshal(ct)
 	if err != nil {
 		return err
@@ -395,19 +367,10 @@ func (service *ContentTypesService) doUpsert(path string, ct *ContentType) error
 	return service.c.do(req, ct)
 }
 
-// Delete the content_type
-func (service *ContentTypesService) Delete(spaceID string, ct *ContentType) error {
-	path := fmt.Sprintf("/spaces/%s/content_types/%s", spaceID, ct.Sys.ID)
-	return service.doDelete(path, ct)
-}
-
-// DeleteFromEnv a content type from an environment
-func (service *ContentTypesService) DeleteFromEnv(env *Environment, ct *ContentType) error {
+// Delete a content type from an environment
+func (service *ContentTypesService) Delete(env *Environment, ct *ContentType) error {
 	path := fmt.Sprintf("/spaces/%s/environments/%s/content_types/%s", env.Sys.Space.Sys.ID, env.Sys.ID, ct.Sys.ID)
-	return service.doDelete(path, ct)
-}
 
-func (service *ContentTypesService) doDelete(path string, ct *ContentType) error {
 	method := "DELETE"
 
 	req, err := service.c.newRequest(method, path, nil, nil)
@@ -422,8 +385,8 @@ func (service *ContentTypesService) doDelete(path string, ct *ContentType) error
 }
 
 // Activate the contenttype, a.k.a publish
-func (service *ContentTypesService) Activate(spaceID string, ct *ContentType) error {
-	path := fmt.Sprintf("/spaces/%s/content_types/%s/published", spaceID, ct.Sys.ID)
+func (service *ContentTypesService) Activate(env *Environment, ct *ContentType) error {
+	path := fmt.Sprintf("/spaces/%s/environments/%s/content_types/%s/published", env.Sys.Space.Sys.ID, env.Sys.ID, ct.Sys.ID)
 	method := "PUT"
 
 	req, err := service.c.newRequest(method, path, nil, nil)
@@ -438,8 +401,8 @@ func (service *ContentTypesService) Activate(spaceID string, ct *ContentType) er
 }
 
 // Deactivate the contenttype, a.k.a unpublish
-func (service *ContentTypesService) Deactivate(spaceID string, ct *ContentType) error {
-	path := fmt.Sprintf("/spaces/%s/content_types/%s/published", spaceID, ct.Sys.ID)
+func (service *ContentTypesService) Deactivate(env *Environment, ct *ContentType) error {
+	path := fmt.Sprintf("/spaces/%s/environments/%s/content_types/%s/published", env.Sys.Space.Sys.ID, env.Sys.ID, ct.Sys.ID)
 	method := "DELETE"
 
 	req, err := service.c.newRequest(method, path, nil, nil)

--- a/content_type_test.go
+++ b/content_type_test.go
@@ -11,10 +11,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var env = &Environment{
+	Sys: &Sys{
+		ID: "env-id",
+		Space: &Space{
+			Sys: &Sys{
+				ID: "space-id",
+			},
+		},
+	},
+}
+
 func ExampleContentTypesService_Get() {
 	cma := NewCMA("cma-token")
-
-	contentType, err := cma.ContentTypes.Get("space-id", "content-type-id")
+	contentType, err := cma.ContentTypes.Get(env, "content-type-id")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -25,7 +35,7 @@ func ExampleContentTypesService_Get() {
 func ExampleContentTypesService_List() {
 	cma := NewCMA("cma-token")
 
-	collection, err := cma.ContentTypes.List("space-id").Next()
+	collection, err := cma.ContentTypes.List(env).Next()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -62,55 +72,7 @@ func ExampleContentTypesService_Upsert_create() {
 		},
 	}
 
-	err := cma.ContentTypes.Upsert("space-id", contentType)
-	if err != nil {
-		log.Fatal(err)
-	}
-}
-
-func ExampleContentTypesService_Upsert_create_with_environment() {
-	cma := NewCMA("cma-token")
-	env := &Environment{
-		Sys: &Sys{
-			ID:       "env-id",
-			LinkType: "env-link-type",
-			Type:     "env-type",
-			Space: &Space{
-				Name:          "space-name",
-				DefaultLocale: "en",
-				Sys: &Sys{
-					ID:       "space-id",
-					LinkType: "space-link-type",
-					Type:     "space-type",
-				},
-			},
-		},
-		Name: "env-name",
-	}
-
-	contentType := &ContentType{
-		Name:         "test content type",
-		DisplayField: "field1_id",
-		Description:  "content type description",
-		Fields: []*Field{
-			{
-				ID:       "field1_id",
-				Name:     "field1",
-				Type:     "Symbol",
-				Required: false,
-				Disabled: false,
-			},
-			{
-				ID:       "field2_id",
-				Name:     "field2",
-				Type:     "Symbol",
-				Required: false,
-				Disabled: true,
-			},
-		},
-	}
-
-	err := cma.ContentTypes.UpsertEnv(env, contentType)
+	err := cma.ContentTypes.Upsert(env, contentType)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -119,47 +81,14 @@ func ExampleContentTypesService_Upsert_create_with_environment() {
 func ExampleContentTypesService_Upsert_Update() {
 	cma := NewCMA("cma-token")
 
-	contentType, err := cma.ContentTypes.Get("space-id", "content-type-id")
+	contentType, err := cma.ContentTypes.Get(env, "content-type-id")
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	contentType.Name = "modified content type name"
 
-	err = cma.ContentTypes.Upsert("space-id", contentType)
-	if err != nil {
-		log.Fatal(err)
-	}
-}
-
-func ExampleContentTypesService_Upsert_Update_With_Environment() {
-	cma := NewCMA("cma-token")
-	env := &Environment{
-		Sys: &Sys{
-			ID:       "env-id",
-			LinkType: "env-link-type",
-			Type:     "env-type",
-			Space: &Space{
-				Name:          "space-name",
-				DefaultLocale: "en",
-				Sys: &Sys{
-					ID:       "space-id",
-					LinkType: "space-link-type",
-					Type:     "space-type",
-				},
-			},
-		},
-		Name: "env-name",
-	}
-
-	contentType, err := cma.ContentTypes.Get("space-id", "content-type-id")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	contentType.Name = "modified content type name"
-
-	err = cma.ContentTypes.UpsertEnv(env, contentType)
+	err = cma.ContentTypes.Upsert(env, contentType)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -168,12 +97,12 @@ func ExampleContentTypesService_Upsert_Update_With_Environment() {
 func ExampleContentTypesService_Activate() {
 	cma := NewCMA("cma-token")
 
-	contentType, err := cma.ContentTypes.Get("space-id", "content-type-id")
+	contentType, err := cma.ContentTypes.Get(env, "content-type-id")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	err = cma.ContentTypes.Activate("space-id", contentType)
+	err = cma.ContentTypes.Activate(env, contentType)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -182,12 +111,12 @@ func ExampleContentTypesService_Activate() {
 func ExampleContentTypesService_Deactivate() {
 	cma := NewCMA("cma-token")
 
-	contentType, err := cma.ContentTypes.Get("space-id", "content-type-id")
+	contentType, err := cma.ContentTypes.Get(env, "content-type-id")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	err = cma.ContentTypes.Deactivate("space-id", contentType)
+	err = cma.ContentTypes.Deactivate(env, contentType)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -196,44 +125,12 @@ func ExampleContentTypesService_Deactivate() {
 func ExampleContentTypesService_Delete() {
 	cma := NewCMA("cma-token")
 
-	contentType, err := cma.ContentTypes.Get("space-id", "content-type-id")
+	contentType, err := cma.ContentTypes.Get(env, "content-type-id")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	err = cma.ContentTypes.Delete("space-id", contentType)
-	if err != nil {
-		log.Fatal(err)
-	}
-}
-
-func ExampleContentTypesService_Delete_with_environment() {
-	cma := NewCMA("cma-token")
-
-	env := &Environment{
-		Sys: &Sys{
-			ID:       "env-id",
-			LinkType: "env-link-type",
-			Type:     "env-type",
-			Space: &Space{
-				Name:          "space-name",
-				DefaultLocale: "en",
-				Sys: &Sys{
-					ID:       "space-id",
-					LinkType: "space-link-type",
-					Type:     "space-type",
-				},
-			},
-		},
-		Name: "env-name",
-	}
-
-	contentType, err := cma.ContentTypes.GetFromEnv(env, "content-type-id")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	err = cma.ContentTypes.DeleteFromEnv(env, contentType)
+	err = cma.ContentTypes.Delete(env, contentType)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -242,7 +139,7 @@ func ExampleContentTypesService_Delete_with_environment() {
 func ExampleContentTypesService_Delete_allDrafts() {
 	cma := NewCMA("cma-token")
 
-	collection, err := cma.ContentTypes.List("space-id").Next()
+	collection, err := cma.ContentTypes.List(env).Next()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -251,7 +148,7 @@ func ExampleContentTypesService_Delete_allDrafts() {
 
 	for _, contentType := range contentTypes {
 		if contentType.Sys.PublishedAt == "" {
-			err := cma.ContentTypes.Delete("space-id", contentType)
+			err := cma.ContentTypes.Delete(env, contentType)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -265,7 +162,7 @@ func TestContentTypesServiceList(t *testing.T) {
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertions.Equal(r.Method, "GET")
-		assertions.Equal(r.URL.Path, "/spaces/"+spaceID+"/content_types")
+		assertions.Equal(r.URL.Path, "/spaces/"+env.Sys.Space.Sys.ID+"/environments/"+env.Sys.ID+"/content_types")
 
 		checkHeaders(r, assertions)
 
@@ -281,7 +178,7 @@ func TestContentTypesServiceList(t *testing.T) {
 	cma = NewCMA(CMAToken)
 	cma.BaseURL = server.URL
 
-	collection, err := cma.ContentTypes.List(spaceID).Next()
+	collection, err := cma.ContentTypes.List(env).Next()
 	assertions.Nil(err)
 	contentType := collection.ToContentType()
 	assertions.Equal(4, len(contentType))
@@ -294,7 +191,7 @@ func TestContentTypesServiceListActivated(t *testing.T) {
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertions.Equal(r.Method, "GET")
-		assertions.Equal(r.URL.Path, "/spaces/"+spaceID+"/public/content_types")
+		assertions.Equal(r.URL.Path, "/spaces/"+env.Sys.Space.Sys.ID+"/environments/"+env.Sys.ID+"/public/content_types")
 
 		checkHeaders(r, assertions)
 
@@ -310,7 +207,7 @@ func TestContentTypesServiceListActivated(t *testing.T) {
 	cma = NewCMA(CMAToken)
 	cma.BaseURL = server.URL
 
-	_, err = cma.ContentTypes.ListActivated(spaceID).Next()
+	_, err = cma.ContentTypes.ListActivated(env).Next()
 	assertions.Nil(err)
 }
 
@@ -320,7 +217,7 @@ func TestContentTypesService_Get(t *testing.T) {
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertions.Equal(r.Method, "GET")
-		assertions.Equal(r.URL.Path, "/spaces/"+spaceID+"/content_types/63Vgs0BFK0USe4i2mQUGK6")
+		assertions.Equal(r.URL.Path, "/spaces/"+env.Sys.Space.Sys.ID+"/environments/"+env.Sys.ID+"/content_types/63Vgs0BFK0USe4i2mQUGK6")
 
 		checkHeaders(r, assertions)
 
@@ -336,7 +233,7 @@ func TestContentTypesService_Get(t *testing.T) {
 	cma = NewCMA(CMAToken)
 	cma.BaseURL = server.URL
 
-	contentType, err := cma.ContentTypes.Get(spaceID, "63Vgs0BFK0USe4i2mQUGK6")
+	contentType, err := cma.ContentTypes.Get(env, "63Vgs0BFK0USe4i2mQUGK6")
 	assertions.Nil(err)
 	assertions.Equal("63Vgs0BFK0USe4i2mQUGK6", contentType.Sys.ID)
 }
@@ -347,7 +244,7 @@ func TestContentTypesService_Get_2(t *testing.T) {
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertions.Equal(r.Method, "GET")
-		assertions.Equal(r.URL.Path, "/spaces/"+spaceID+"/content_types/63Vgs0BFK0USe4i2mQUGK6")
+		assertions.Equal(r.URL.Path, "/spaces/"+env.Sys.Space.Sys.ID+"/environments/"+env.Sys.ID+"/content_types/63Vgs0BFK0USe4i2mQUGK6")
 
 		checkHeaders(r, assertions)
 
@@ -363,7 +260,7 @@ func TestContentTypesService_Get_2(t *testing.T) {
 	cma = NewCMA(CMAToken)
 	cma.BaseURL = server.URL
 
-	_, err = cma.ContentTypes.Get(spaceID, "63Vgs0BFK0USe4i2mQUGK6")
+	_, err = cma.ContentTypes.Get(env, "63Vgs0BFK0USe4i2mQUGK6")
 	assertions.NotNil(err)
 }
 
@@ -373,7 +270,7 @@ func TestContentTypesServiceActivate(t *testing.T) {
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertions.Equal(r.Method, "PUT")
-		assertions.Equal(r.URL.Path, "/spaces/"+spaceID+"/content_types/63Vgs0BFK0USe4i2mQUGK6/published")
+		assertions.Equal(r.URL.Path, "/spaces/"+env.Sys.Space.Sys.ID+"/environments/"+env.Sys.ID+"/content_types/63Vgs0BFK0USe4i2mQUGK6/published")
 
 		checkHeaders(r, assertions)
 
@@ -393,7 +290,7 @@ func TestContentTypesServiceActivate(t *testing.T) {
 	ct, err := contentTypeFromTestData("content_type.json")
 	assertions.Nil(err)
 
-	err = cma.ContentTypes.Activate(spaceID, ct)
+	err = cma.ContentTypes.Activate(env, ct)
 	assertions.Nil(err)
 }
 
@@ -403,7 +300,7 @@ func TestContentTypesServiceDeactivate(t *testing.T) {
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertions.Equal(r.Method, "DELETE")
-		assertions.Equal(r.URL.Path, "/spaces/"+spaceID+"/content_types/63Vgs0BFK0USe4i2mQUGK6/published")
+		assertions.Equal(r.URL.Path, "/spaces/"+env.Sys.Space.Sys.ID+"/environments/"+env.Sys.ID+"/content_types/63Vgs0BFK0USe4i2mQUGK6/published")
 
 		checkHeaders(r, assertions)
 
@@ -423,7 +320,7 @@ func TestContentTypesServiceDeactivate(t *testing.T) {
 	ct, err := contentTypeFromTestData("content_type.json")
 	assertions.Nil(err)
 
-	err = cma.ContentTypes.Deactivate(spaceID, ct)
+	err = cma.ContentTypes.Deactivate(env, ct)
 	assertions.Nil(err)
 }
 
@@ -433,7 +330,7 @@ func TestContentTypeSaveForCreate(t *testing.T) {
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertions.Equal(r.Method, "PUT")
-		assertions.Equal(r.RequestURI, "/spaces/"+spaceID+"/content_types/ct-name")
+		assertions.Equal(r.RequestURI, "/spaces/"+env.Sys.Space.Sys.ID+"/environments/"+env.Sys.ID+"/content_types/ct-name")
 		checkHeaders(r, assertions)
 
 		var payload map[string]interface{}
@@ -492,7 +389,7 @@ func TestContentTypeSaveForCreate(t *testing.T) {
 		DisplayField: field1.ID,
 	}
 
-	err = cma.ContentTypes.Upsert("id1", ct)
+	err = cma.ContentTypes.Upsert(env, ct)
 	assertions.Nil(err)
 	assertions.Equal("63Vgs0BFK0USe4i2mQUGK6", ct.Sys.ID)
 	assertions.Equal("ct-name", ct.Name)
@@ -505,7 +402,7 @@ func TestContentTypeSaveForUpdate(t *testing.T) {
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertions.Equal(r.Method, "PUT")
-		assertions.Equal(r.RequestURI, "/spaces/"+spaceID+"/content_types/63Vgs0BFK0USe4i2mQUGK6")
+		assertions.Equal(r.RequestURI, "/spaces/"+env.Sys.Space.Sys.ID+"/environments/"+env.Sys.ID+"/content_types/63Vgs0BFK0USe4i2mQUGK6")
 		checkHeaders(r, assertions)
 
 		var payload map[string]interface{}
@@ -574,7 +471,7 @@ func TestContentTypeSaveForUpdate(t *testing.T) {
 	ct.Fields = append(ct.Fields, field3)
 	ct.DisplayField = ct.Fields[2].ID
 
-	_ = cma.ContentTypes.Upsert("id1", ct)
+	_ = cma.ContentTypes.Upsert(env, ct)
 	assertions.Nil(err)
 	assertions.Equal("63Vgs0BFK0USe4i2mQUGK6", ct.Sys.ID)
 	assertions.Equal("ct-name-updated", ct.Name)
@@ -588,7 +485,7 @@ func TestContentTypeCreateWithID(t *testing.T) {
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertions.Equal(r.Method, "PUT")
-		assertions.Equal(r.RequestURI, "/spaces/id1/content_types/mycontenttype")
+		assertions.Equal(r.RequestURI, "/spaces/"+env.Sys.Space.Sys.ID+"/environments/"+env.Sys.ID+"/content_types/mycontenttype")
 		checkHeaders(r, assertions)
 
 		w.WriteHeader(200)
@@ -611,7 +508,7 @@ func TestContentTypeCreateWithID(t *testing.T) {
 		Name: "MyContentType",
 	}
 
-	_ = cma.ContentTypes.Upsert("id1", ct)
+	_ = cma.ContentTypes.Upsert(env, ct)
 	assertions.Nil(err)
 }
 
@@ -621,7 +518,7 @@ func TestContentTypeDelete(t *testing.T) {
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertions.Equal(r.Method, "DELETE")
-		assertions.Equal(r.RequestURI, "/spaces/"+spaceID+"/content_types/63Vgs0BFK0USe4i2mQUGK6")
+		assertions.Equal(r.RequestURI, "/spaces/"+env.Sys.Space.Sys.ID+"/environments/"+env.Sys.ID+"/content_types/63Vgs0BFK0USe4i2mQUGK6")
 		checkHeaders(r, assertions)
 
 		w.WriteHeader(200)
@@ -640,7 +537,7 @@ func TestContentTypeDelete(t *testing.T) {
 	assertions.Nil(err)
 
 	// delete content type
-	err = cma.ContentTypes.Delete("id1", ct)
+	err = cma.ContentTypes.Delete(env, ct)
 	assertions.Nil(err)
 }
 
@@ -650,7 +547,7 @@ func TestContentTypeFieldRef(t *testing.T) {
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertions.Equal(r.Method, "PUT")
-		assertions.Equal(r.RequestURI, "/spaces/"+spaceID+"/content_types/ct-name")
+		assertions.Equal(r.RequestURI, "/spaces/"+env.Sys.Space.Sys.ID+"/environments/"+env.Sys.ID+"/content_types/ct-name")
 		checkHeaders(r, assertions)
 
 		var payload map[string]interface{}
@@ -703,7 +600,7 @@ func TestContentTypeFieldRef(t *testing.T) {
 		DisplayField: field1.ID,
 	}
 
-	err = cma.ContentTypes.Upsert("id1", ct)
+	err = cma.ContentTypes.Upsert(env, ct)
 	assertions.Nil(err)
 }
 
@@ -713,7 +610,7 @@ func TestContentTypeFieldArray(t *testing.T) {
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertions.Equal(r.Method, "PUT")
-		assertions.Equal(r.RequestURI, "/spaces/"+spaceID+"/content_types/ct-name")
+		assertions.Equal(r.RequestURI, "/spaces/"+env.Sys.Space.Sys.ID+"/environments/"+env.Sys.ID+"/content_types/ct-name")
 		checkHeaders(r, assertions)
 
 		var payload map[string]interface{}
@@ -766,7 +663,7 @@ func TestContentTypeFieldArray(t *testing.T) {
 		DisplayField: field1.ID,
 	}
 
-	err = cma.ContentTypes.Upsert("id1", ct)
+	err = cma.ContentTypes.Upsert(env, ct)
 	assertions.Nil(err)
 }
 
@@ -776,7 +673,7 @@ func TestContentTypeFieldValidationRangeUniquePredefinedValues(t *testing.T) {
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertions.Equal(r.Method, "PUT")
-		assertions.Equal(r.RequestURI, "/spaces/"+spaceID+"/content_types/ct-name")
+		assertions.Equal(r.RequestURI, "/spaces/"+env.Sys.Space.Sys.ID+"/environments/"+env.Sys.ID+"/content_types/ct-name")
 		checkHeaders(r, assertions)
 
 		var payload map[string]interface{}
@@ -853,7 +750,7 @@ func TestContentTypeFieldValidationRangeUniquePredefinedValues(t *testing.T) {
 		DisplayField: field1.ID,
 	}
 
-	err = cma.ContentTypes.Upsert("id1", ct)
+	err = cma.ContentTypes.Upsert(env, ct)
 	assertions.Nil(err)
 }
 
@@ -863,7 +760,7 @@ func TestContentTypeFieldTypeMedia(t *testing.T) {
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertions.Equal(r.Method, "PUT")
-		assertions.Equal(r.RequestURI, "/spaces/"+spaceID+"/content_types/ct-name")
+		assertions.Equal(r.RequestURI, "/spaces/"+env.Sys.Space.Sys.ID+"/environments/"+env.Sys.ID+"/content_types/ct-name")
 		checkHeaders(r, assertions)
 
 		var payload map[string]interface{}
@@ -988,7 +885,7 @@ func TestContentTypeFieldTypeMedia(t *testing.T) {
 		DisplayField: field1.ID,
 	}
 
-	err = cma.ContentTypes.Upsert("id1", ct)
+	err = cma.ContentTypes.Upsert(env, ct)
 	assertions.Nil(err)
 }
 
@@ -1007,7 +904,7 @@ func TestContentTypeFieldValidationsUnmarshal(t *testing.T) {
 	cma = NewCMA(CMAToken)
 	cma.BaseURL = server.URL
 
-	ct, err := cma.ContentTypes.Get(spaceID, "validationsTest")
+	ct, err := cma.ContentTypes.Get(env, "validationsTest")
 	assertions.Nil(err)
 
 	var uniqueValidations []FieldValidation


### PR DESCRIPTION
Changes the API for content type operations so that instead of accepting
a space id, instead they accept an environment